### PR TITLE
make example image link work on napari-hub.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Napari plugin for skeleton computation on 2D gray-scale images. Currently supp
 4. Skeleton colored by distance to the boundary
 5. Only support single png or jpg images
 
-![example](imgs/horse.png)
+![example](https://github.com/teeli8/skeleton-finder/raw/main/imgs/horse.png)
 
 
 ## Usage


### PR DESCRIPTION
Hi @teeli8 ,

congrats to this super cool napari plugin!

With this little change, the example image will be shown on the [plugin page on the napari hub](https://www.napari-hub.org/plugins/skeleton-finder).

After merging, you need to make a new release to update the napari hub page.

Let me know what you think!

Best,
Robert
